### PR TITLE
feat: add `user_id` and `login` fields to the resetting-reset endpoint response

### DIFF
--- a/auth/routes/resetting.go
+++ b/auth/routes/resetting.go
@@ -211,6 +211,8 @@ func resettingResetHandler(c *gin.Context) {
 	})
 
 	c.JSON(http.StatusOK, gin.H{
-		"status": "ok",
+		"status":  "ok",
+		"user_id": apiUser.GetID(),
+		"login":   apiUser.GetLogin(),
 	})
 }


### PR DESCRIPTION
## Summary
- Adds `user_id` and `login` fields to the `resettingResetHandler` response, matching the pattern already used in registration endpoints
- Response changes from `{"status": "ok"}` to `{"status": "ok", "user_id": "...", "login": "..."}`

## Jira
AIMS-5100

## Test plan
- [x] E2E tests: 4/4 pass (happy path, invalid token, weak password, missing password)
- [ ] Deploy to staging and verify via Postman on both `api-staging` and `auto-tagging-api-staging` domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Password reset endpoint response now includes user identification information in addition to the confirmation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->