### PR TITLE
feat: order access-scope regexes by specificity and cache compilations

### DIFF
--- a/auth/contract/entity.go
+++ b/auth/contract/entity.go
@@ -1,11 +1,82 @@
 package contract
 
 import (
+	"cmp"
 	"github.com/wernerdweight/api-auth-go/v2/auth/constants"
 	"regexp"
+	"slices"
 	"strings"
+	"sync"
 	"time"
 )
+
+// regexScopePrefix marks a scope key as a regex pattern. The prefix is stripped
+// before compilation.
+const regexScopePrefix = "r#"
+
+// regexCache memoizes compiled regex patterns so that access-scope checking
+// does not recompile the same regex on every request. Patterns that fail to
+// compile are stored as a nil *regexp.Regexp so that we only log/attempt
+// compilation once.
+var regexCache sync.Map // map[string]*regexp.Regexp
+
+// getCompiledScopeRegex returns the compiled regex for the given pattern,
+// using a process-wide cache. A nil *regexp.Regexp is returned (and cached)
+// for patterns that fail to compile.
+func getCompiledScopeRegex(pattern string) *regexp.Regexp {
+	if cached, ok := regexCache.Load(pattern); ok {
+		if cached == nil {
+			return nil
+		}
+		return cached.(*regexp.Regexp)
+	}
+	compiled, err := regexp.Compile(pattern)
+	if err != nil {
+		regexCache.Store(pattern, (*regexp.Regexp)(nil))
+		return nil
+	}
+	regexCache.Store(pattern, compiled)
+	return compiled
+}
+
+// sortedRegexScopeKeys returns the regex-enabled keys (those starting with
+// regexScopePrefix) from the given map, sorted by pattern length descending so
+// that "more specific" regexes are tried first. Ties are broken
+// lexicographically to give deterministic ordering.
+func sortedRegexScopeKeys(scope map[string]any) []string {
+	var keys []string
+	for k := range scope {
+		if strings.HasPrefix(k, regexScopePrefix) {
+			keys = append(keys, k)
+		}
+	}
+	slices.SortFunc(keys, func(a, b string) int {
+		if d := len(b) - len(a); d != 0 {
+			return d
+		}
+		return cmp.Compare(a, b)
+	})
+	return keys
+}
+
+// lookupScopeEntry finds the value associated with segment in scope. Exact
+// matches always win; otherwise regex-enabled keys are tried in
+// most-specific-first order (see sortedRegexScopeKeys).
+func lookupScopeEntry(scope map[string]any, segment string) (any, bool) {
+	if value, ok := scope[segment]; ok {
+		return value, true
+	}
+	for _, scopeEntry := range sortedRegexScopeKeys(scope) {
+		re := getCompiledScopeRegex(scopeEntry[len(regexScopePrefix):])
+		if re == nil {
+			continue
+		}
+		if re.MatchString(segment) {
+			return scope[scopeEntry], true
+		}
+	}
+	return nil, false
+}
 
 type AccessScope map[string]any
 
@@ -31,48 +102,27 @@ func (s AccessScope) getBoolAccessibility(index int, pathSegments []string, type
 }
 
 func (s AccessScope) GetAccessibility(key string, hierarchySeparator string) constants.ScopeAccessibility {
-	currentScope := s
 	if hierarchySeparator == "" {
 		hierarchySeparator = "|"
 	}
 	pathSegments := strings.Split(key, hierarchySeparator)
-	index := 0
-	for _, segment := range pathSegments {
-		if value, ok := currentScope[segment]; ok {
-			if typedValue, ok := value.(AccessScope); ok {
-				currentScope = typedValue
-				index++
-				continue
-			}
-			if typedValue, ok := value.(string); ok {
-				return s.getStringAccessibility(index, pathSegments, typedValue)
-			}
-			if typedValue, ok := value.(bool); ok {
-				return s.getBoolAccessibility(index, pathSegments, typedValue)
-			}
+	currentScope := s
+	for index, segment := range pathSegments {
+		value, ok := lookupScopeEntry(currentScope, segment)
+		if !ok {
+			return constants.ScopeAccessibilityForbidden
 		}
-		for scopeEntry, value := range currentScope {
-			// regex-enabled scope keys must start with `r#`
-			if strings.Index(scopeEntry, "r#") != 0 {
-				continue
-			}
-			scopeEntryRegex, err := regexp.Compile(scopeEntry[2:])
-			if nil == err {
-				if scopeEntryRegex.MatchString(segment) {
-					if typedValue, ok := value.(AccessScope); ok {
-						currentScope = typedValue
-						index++
-						continue
-					}
-					if typedValue, ok := value.(string); ok {
-						return s.getStringAccessibility(index, pathSegments, typedValue)
-					}
-					if typedValue, ok := value.(bool); ok {
-						return s.getBoolAccessibility(index, pathSegments, typedValue)
-					}
-				}
-			}
+		if nested, ok := value.(AccessScope); ok {
+			currentScope = nested
+			continue
 		}
+		if typedValue, ok := value.(string); ok {
+			return s.getStringAccessibility(index, pathSegments, typedValue)
+		}
+		if typedValue, ok := value.(bool); ok {
+			return s.getBoolAccessibility(index, pathSegments, typedValue)
+		}
+		return constants.ScopeAccessibilityForbidden
 	}
 	return constants.ScopeAccessibilityForbidden
 }
@@ -103,91 +153,47 @@ func (s FUPScope) getFloat32Limit(index int, pathSegments []string, typedValue f
 }
 
 func (s FUPScope) GetLimit(key string) *int {
-	currentScope := s
 	pathSegments := strings.Split(key, ".")
-	index := 0
-	for _, segment := range pathSegments {
-		if value, ok := currentScope[segment]; ok {
-			if typedValue, ok := value.(map[string]any); ok {
-				currentScope = typedValue
-				index++
-				continue
-			}
-			if typedValue, ok := value.(int); ok {
-				return s.getIntLimit(index, pathSegments, typedValue)
-			}
-			if typedValue, ok := value.(float64); ok {
-				return s.getFloat64Limit(index, pathSegments, typedValue)
-			}
-			if typedValue, ok := value.(float32); ok {
-				return s.getFloat32Limit(index, pathSegments, typedValue)
-			}
+	currentScope := map[string]any(s)
+	for index, segment := range pathSegments {
+		value, ok := lookupScopeEntry(currentScope, segment)
+		if !ok {
+			return nil
 		}
-		for scopeEntry, value := range currentScope {
-			// regex-enabled scope keys must start with `r#`
-			if strings.Index(scopeEntry, "r#") != 0 {
-				continue
-			}
-			scopeEntryRegex, err := regexp.Compile(scopeEntry[2:])
-			if nil == err {
-				if scopeEntryRegex.MatchString(segment) {
-					if typedValue, ok := value.(map[string]any); ok {
-						currentScope = typedValue
-						index++
-						continue
-					}
-					if typedValue, ok := value.(int); ok {
-						return s.getIntLimit(index, pathSegments, typedValue)
-					}
-					if typedValue, ok := value.(float64); ok {
-						return s.getFloat64Limit(index, pathSegments, typedValue)
-					}
-					if typedValue, ok := value.(float32); ok {
-						return s.getFloat32Limit(index, pathSegments, typedValue)
-					}
-				}
-			}
+		if nested, ok := value.(map[string]any); ok {
+			currentScope = nested
+			continue
 		}
+		if typedValue, ok := value.(int); ok {
+			return s.getIntLimit(index, pathSegments, typedValue)
+		}
+		if typedValue, ok := value.(float64); ok {
+			return s.getFloat64Limit(index, pathSegments, typedValue)
+		}
+		if typedValue, ok := value.(float32); ok {
+			return s.getFloat32Limit(index, pathSegments, typedValue)
+		}
+		return nil
 	}
 	return nil
 }
 
 func (s FUPScope) HasLimit(key string) bool {
-	currentScope := s
 	pathSegments := strings.Split(key, ".")
-	index := 0
-	for _, segment := range pathSegments {
-		if value, ok := currentScope[segment]; ok {
-			if typedValue, ok := value.(map[string]any); ok {
-				currentScope = typedValue
-				if index == len(pathSegments)-1 {
-					return true
-				}
-				index++
-				continue
-			}
+	currentScope := map[string]any(s)
+	for index, segment := range pathSegments {
+		value, ok := lookupScopeEntry(currentScope, segment)
+		if !ok {
 			return false
 		}
-		for scopeEntry, value := range currentScope {
-			// regex-enabled scope keys must start with `r#`
-			if strings.Index(scopeEntry, "r#") != 0 {
-				continue
+		if nested, ok := value.(map[string]any); ok {
+			if index == len(pathSegments)-1 {
+				return true
 			}
-			scopeEntryRegex, err := regexp.Compile(scopeEntry[2:])
-			if nil == err {
-				if scopeEntryRegex.MatchString(segment) {
-					if typedValue, ok := value.(map[string]any); ok {
-						currentScope = typedValue
-						if index == len(pathSegments)-1 {
-							return true
-						}
-						index++
-						continue
-					}
-					return false
-				}
-			}
+			currentScope = nested
+			continue
 		}
+		return false
 	}
 	return false
 }

--- a/auth/contract/entity.go
+++ b/auth/contract/entity.go
@@ -14,29 +14,33 @@ import (
 // before compilation.
 const regexScopePrefix = "r#"
 
+// cachedScopeRegex holds a compiled regex behind a sync.Once so that
+// concurrent lookups of the same pattern compile it exactly once, even under
+// contention. A nil re means the pattern failed to compile.
+type cachedScopeRegex struct {
+	once sync.Once
+	re   *regexp.Regexp
+}
+
 // regexCache memoizes compiled regex patterns so that access-scope checking
 // does not recompile the same regex on every request. Patterns that fail to
-// compile are stored as a nil *regexp.Regexp so that we only log/attempt
-// compilation once.
-var regexCache sync.Map // map[string]*regexp.Regexp
+// compile are stored as a cachedScopeRegex with a nil re, so the failure is
+// also cached.
+var regexCache sync.Map // map[string]*cachedScopeRegex
 
 // getCompiledScopeRegex returns the compiled regex for the given pattern,
 // using a process-wide cache. A nil *regexp.Regexp is returned (and cached)
-// for patterns that fail to compile.
+// for patterns that fail to compile. Concurrent callers requesting the same
+// pattern will share a single compilation.
 func getCompiledScopeRegex(pattern string) *regexp.Regexp {
-	if cached, ok := regexCache.Load(pattern); ok {
-		if cached == nil {
-			return nil
-		}
-		return cached.(*regexp.Regexp)
-	}
-	compiled, err := regexp.Compile(pattern)
-	if err != nil {
-		regexCache.Store(pattern, (*regexp.Regexp)(nil))
-		return nil
-	}
-	regexCache.Store(pattern, compiled)
-	return compiled
+	entryAny, _ := regexCache.LoadOrStore(pattern, &cachedScopeRegex{})
+	entry := entryAny.(*cachedScopeRegex)
+	entry.once.Do(func() {
+		// A compile error leaves entry.re as nil, which is the documented
+		// "invalid pattern" signal to callers.
+		entry.re, _ = regexp.Compile(pattern)
+	})
+	return entry.re
 }
 
 // sortedRegexScopeKeys returns the regex-enabled keys (those starting with

--- a/auth/contract/entity_test.go
+++ b/auth/contract/entity_test.go
@@ -3,6 +3,7 @@ package contract
 import (
 	"github.com/wernerdweight/api-auth-go/v2/auth/constants"
 	"regexp"
+	"sync"
 	"testing"
 )
 
@@ -443,15 +444,51 @@ func TestGetCompiledScopeRegex_CachesAndHandlesInvalid(t *testing.T) {
 	if got := getCompiledScopeRegex(invalidPattern); got != nil {
 		t.Errorf("getCompiledScopeRegex(%q) second call = %v, want nil (cached)", invalidPattern, got)
 	}
-	// The invalid entry should be present in the cache as a nil value.
-	if cached, ok := regexCache.Load(invalidPattern); !ok {
-		t.Errorf("invalid pattern was not cached")
-	} else if cached != nil {
-		// We explicitly store a typed nil, which survives as an interface
-		// holding (*regexp.Regexp)(nil); it is not == nil in a generic sense,
-		// but the value read out of it must itself be a nil pointer.
-		if rp, ok := cached.(*regexp.Regexp); !ok || rp != nil {
-			t.Errorf("invalid pattern cache entry = %#v, want typed nil *regexp.Regexp", cached)
+	// The invalid entry should be present in the cache as a cachedScopeRegex
+	// whose compiled regex is nil.
+	cached, ok := regexCache.Load(invalidPattern)
+	if !ok {
+		t.Fatalf("invalid pattern was not cached")
+	}
+	entry, ok := cached.(*cachedScopeRegex)
+	if !ok {
+		t.Fatalf("invalid pattern cache entry = %#v, want *cachedScopeRegex", cached)
+	}
+	if entry.re != nil {
+		t.Errorf("invalid pattern cache entry has non-nil compiled regex: %#v", entry.re)
+	}
+}
+
+func TestGetCompiledScopeRegex_ConcurrentCompilesOnce(t *testing.T) {
+	// Hammer the cache with many goroutines requesting the same fresh
+	// pattern; they must all see the same *regexp.Regexp pointer, and the
+	// cache entry must only exist once.
+	pattern := "^/concurrent-test/[0-9]+/item$"
+	defer regexCache.Delete(pattern)
+
+	const goroutines = 64
+	results := make([]*regexp.Regexp, goroutines)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			<-start
+			results[i] = getCompiledScopeRegex(pattern)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	first := results[0]
+	if first == nil {
+		t.Fatalf("getCompiledScopeRegex returned nil for a valid pattern")
+	}
+	for i, got := range results {
+		if got != first {
+			t.Errorf("goroutine %d got different *regexp.Regexp pointer (%p) than goroutine 0 (%p)", i, got, first)
 		}
 	}
 }
@@ -595,11 +632,13 @@ func TestFUPScope_GetLimit_HasLimit(t *testing.T) {
 			has:   false,
 		},
 		// FUPScope specificity ordering: more specific regex wins over broader one.
+		// Both patterns must match the path segment for the test to actually
+		// exercise precedence — hence the `(/.*)?$` on the broad regex.
 		{
 			name: "FUP regex ordering: specific regex wins over broad",
 			scope: FUPScope{
-				"r#^/api/v[0-9]+$":          map[string]any{"hourly": 321},
-				"r#^/api/v[0-9]+/premium$":  map[string]any{"hourly": 123},
+				"r#^/api/v[0-9]+(/.*)?$":   map[string]any{"hourly": 321},
+				"r#^/api/v[0-9]+/premium$": map[string]any{"hourly": 123},
 			},
 			args: args{path: "/api/v1/premium.hourly"},
 			want: &testValue,
@@ -608,7 +647,7 @@ func TestFUPScope_GetLimit_HasLimit(t *testing.T) {
 		{
 			name: "FUP regex ordering: broad regex used when specific does not match",
 			scope: FUPScope{
-				"r#^/api/v[0-9]+$":         map[string]any{"hourly": 123},
+				"r#^/api/v[0-9]+(/.*)?$":   map[string]any{"hourly": 123},
 				"r#^/api/v[0-9]+/premium$": map[string]any{"hourly": 321},
 			},
 			args: args{path: "/api/v1.hourly"},

--- a/auth/contract/entity_test.go
+++ b/auth/contract/entity_test.go
@@ -255,9 +255,9 @@ func TestAccessScope_GetAccessibility(t *testing.T) {
 		{
 			name: "Regex ordering: three regexes, middle one wins",
 			scope: AccessScope{
-				"r#^/a/.*$":                    true,
-				"r#^/a/b/.*$":                  false,
-				"r#^/a/b/c/very/specific/.*$":  "on-behalf",
+				"r#^/a/.*$":                   true,
+				"r#^/a/b/.*$":                 false,
+				"r#^/a/b/c/very/specific/.*$": "on-behalf",
 			},
 			args: args{path: "/a/b/other"},
 			want: constants.ScopeAccessibilityForbidden,
@@ -265,9 +265,9 @@ func TestAccessScope_GetAccessibility(t *testing.T) {
 		{
 			name: "Regex ordering: three regexes, most specific wins",
 			scope: AccessScope{
-				"r#^/a/.*$":                    true,
-				"r#^/a/b/.*$":                  false,
-				"r#^/a/b/c/very/specific/.*$":  "on-behalf",
+				"r#^/a/.*$":                   true,
+				"r#^/a/b/.*$":                 false,
+				"r#^/a/b/c/very/specific/.*$": "on-behalf",
 			},
 			args: args{path: "/a/b/c/very/specific/thing"},
 			want: constants.ScopeAccessibilityOnBehalf,
@@ -275,9 +275,9 @@ func TestAccessScope_GetAccessibility(t *testing.T) {
 		{
 			name: "Regex ordering: three regexes, least specific wins when others miss",
 			scope: AccessScope{
-				"r#^/a/.*$":                    true,
-				"r#^/a/b/.*$":                  false,
-				"r#^/a/b/c/very/specific/.*$":  "on-behalf",
+				"r#^/a/.*$":                   true,
+				"r#^/a/b/.*$":                 false,
+				"r#^/a/b/c/very/specific/.*$": "on-behalf",
 			},
 			args: args{path: "/a/something"},
 			want: constants.ScopeAccessibilityAccessible,
@@ -321,8 +321,8 @@ func TestAccessScope_GetAccessibility(t *testing.T) {
 			name: "Regex ordering: nested scope with specificity at leaf level",
 			scope: AccessScope{
 				"api": AccessScope{
-					"r#^/users/.*$":         true,
-					"r#^/users/admin/.*$":   false,
+					"r#^/users/.*$":       true,
+					"r#^/users/admin/.*$": false,
 				},
 			},
 			args: args{path: "api|/users/admin/delete"},
@@ -332,8 +332,8 @@ func TestAccessScope_GetAccessibility(t *testing.T) {
 			name: "Regex ordering: nested scope with specificity at leaf level, allow case",
 			scope: AccessScope{
 				"api": AccessScope{
-					"r#^/users/.*$":         true,
-					"r#^/users/admin/.*$":   false,
+					"r#^/users/.*$":       true,
+					"r#^/users/admin/.*$": false,
 				},
 			},
 			args: args{path: "api|/users/42"},
@@ -368,9 +368,9 @@ func TestSortedRegexScopeKeys(t *testing.T) {
 		{
 			name: "Mixed keys — only regex keys are returned",
 			scope: map[string]any{
-				"/literal":     true,
-				"r#^/a/.*$":    true,
-				"another-lit":  false,
+				"/literal":      true,
+				"r#^/a/.*$":     true,
+				"another-lit":   false,
 				"r#^/longer/.$": true,
 			},
 			want: []string{"r#^/longer/.$", "r#^/a/.*$"},
@@ -378,9 +378,9 @@ func TestSortedRegexScopeKeys(t *testing.T) {
 		{
 			name: "Length-descending ordering",
 			scope: map[string]any{
-				"r#^/short$":                          true,
-				"r#^/much/much/longer/pattern/here$":  true,
-				"r#^/medium/length$":                  true,
+				"r#^/short$":                         true,
+				"r#^/much/much/longer/pattern/here$": true,
+				"r#^/medium/length$":                 true,
 			},
 			want: []string{
 				"r#^/much/much/longer/pattern/here$",

--- a/auth/contract/entity_test.go
+++ b/auth/contract/entity_test.go
@@ -166,6 +166,178 @@ func TestAccessScope_GetAccessibility(t *testing.T) {
 			args:  args{path: "nested1|/test/abC-1De23f|nested2"},
 			want:  constants.ScopeAccessibilityOnBehalf,
 		},
+		// Specificity-ordering cases: longer (more specific) regex keys must
+		// be tried before shorter ones, so deny rules can shadow broader allow
+		// rules regardless of map iteration order.
+		{
+			name: "Regex ordering: specific deny shadows broad allow (chat)",
+			scope: AccessScope{
+				"r#^/similarity/v[0-9]+/.*$":                true,
+				"r#^/similarity/v[0-9]+/(chat|sessions).*$": false,
+			},
+			args: args{path: "/similarity/v1/chat"},
+			want: constants.ScopeAccessibilityForbidden,
+		},
+		{
+			name: "Regex ordering: specific deny shadows broad allow (sessions nested)",
+			scope: AccessScope{
+				"r#^/similarity/v[0-9]+/.*$":                true,
+				"r#^/similarity/v[0-9]+/(chat|sessions).*$": false,
+			},
+			args: args{path: "/similarity/v2/sessions/123/messages"},
+			want: constants.ScopeAccessibilityForbidden,
+		},
+		{
+			name: "Regex ordering: broad allow still matches when specific deny does not",
+			scope: AccessScope{
+				"r#^/similarity/v[0-9]+/.*$":                true,
+				"r#^/similarity/v[0-9]+/(chat|sessions).*$": false,
+			},
+			args: args{path: "/similarity/v1/anything"},
+			want: constants.ScopeAccessibilityAccessible,
+		},
+		{
+			name: "Regex ordering: unrelated path still forbidden",
+			scope: AccessScope{
+				"r#^/similarity/v[0-9]+/.*$":                true,
+				"r#^/similarity/v[0-9]+/(chat|sessions).*$": false,
+			},
+			args: args{path: "/other/v1/anything"},
+			want: constants.ScopeAccessibilityForbidden,
+		},
+		{
+			name: "Regex ordering: full example with exact allow",
+			scope: AccessScope{
+				"/token/generate":                           true,
+				"r#^/similarity/v[0-9]+/.*$":                true,
+				"r#^/similarity/v[0-9]+/(chat|sessions).*$": false,
+			},
+			args: args{path: "/token/generate"},
+			want: constants.ScopeAccessibilityAccessible,
+		},
+		{
+			name: "Regex ordering: exact match beats regex even when regex is more specific",
+			scope: AccessScope{
+				"/similarity/v1/chat":                       true,
+				"r#^/similarity/v[0-9]+/(chat|sessions).*$": false,
+			},
+			args: args{path: "/similarity/v1/chat"},
+			want: constants.ScopeAccessibilityAccessible,
+		},
+		{
+			name: "Regex ordering: on-behalf from more specific regex wins over broad allow",
+			scope: AccessScope{
+				"r#^/admin/.*$":       true,
+				"r#^/admin/users/.*$": "on-behalf",
+			},
+			args: args{path: "/admin/users/42"},
+			want: constants.ScopeAccessibilityOnBehalf,
+		},
+		{
+			name: "Regex ordering: broad on-behalf used when specific deny does not match",
+			scope: AccessScope{
+				"r#^/admin/.*$":                 "on-behalf",
+				"r#^/admin/internal/secret/.+$": false,
+			},
+			args: args{path: "/admin/users/42"},
+			want: constants.ScopeAccessibilityOnBehalf,
+		},
+		{
+			name: "Regex ordering: specific deny wins over broad on-behalf",
+			scope: AccessScope{
+				"r#^/admin/.*$":                 "on-behalf",
+				"r#^/admin/internal/secret/.+$": false,
+			},
+			args: args{path: "/admin/internal/secret/42"},
+			want: constants.ScopeAccessibilityForbidden,
+		},
+		{
+			name: "Regex ordering: three regexes, middle one wins",
+			scope: AccessScope{
+				"r#^/a/.*$":                    true,
+				"r#^/a/b/.*$":                  false,
+				"r#^/a/b/c/very/specific/.*$":  "on-behalf",
+			},
+			args: args{path: "/a/b/other"},
+			want: constants.ScopeAccessibilityForbidden,
+		},
+		{
+			name: "Regex ordering: three regexes, most specific wins",
+			scope: AccessScope{
+				"r#^/a/.*$":                    true,
+				"r#^/a/b/.*$":                  false,
+				"r#^/a/b/c/very/specific/.*$":  "on-behalf",
+			},
+			args: args{path: "/a/b/c/very/specific/thing"},
+			want: constants.ScopeAccessibilityOnBehalf,
+		},
+		{
+			name: "Regex ordering: three regexes, least specific wins when others miss",
+			scope: AccessScope{
+				"r#^/a/.*$":                    true,
+				"r#^/a/b/.*$":                  false,
+				"r#^/a/b/c/very/specific/.*$":  "on-behalf",
+			},
+			args: args{path: "/a/something"},
+			want: constants.ScopeAccessibilityAccessible,
+		},
+		{
+			name: "Regex ordering: invalid regex is skipped, valid specific regex wins",
+			scope: AccessScope{
+				"r#^/broken/(unterminated": true,
+				"r#^/ok/.*$":               true,
+			},
+			args: args{path: "/ok/something"},
+			want: constants.ScopeAccessibilityAccessible,
+		},
+		{
+			name: "Regex ordering: invalid regex is skipped, no fallthrough to broken entry",
+			scope: AccessScope{
+				"r#^/broken/(unterminated": true,
+			},
+			args: args{path: "/broken/unterminated"},
+			want: constants.ScopeAccessibilityForbidden,
+		},
+		{
+			name: "Regex ordering: deterministic on length tie",
+			scope: AccessScope{
+				"r#^/tied/a$": true,
+				"r#^/tied/b$": false,
+			},
+			args: args{path: "/tied/a"},
+			want: constants.ScopeAccessibilityAccessible,
+		},
+		{
+			name: "Regex ordering: deterministic on length tie, second path",
+			scope: AccessScope{
+				"r#^/tied/a$": true,
+				"r#^/tied/b$": false,
+			},
+			args: args{path: "/tied/b"},
+			want: constants.ScopeAccessibilityForbidden,
+		},
+		{
+			name: "Regex ordering: nested scope with specificity at leaf level",
+			scope: AccessScope{
+				"api": AccessScope{
+					"r#^/users/.*$":         true,
+					"r#^/users/admin/.*$":   false,
+				},
+			},
+			args: args{path: "api|/users/admin/delete"},
+			want: constants.ScopeAccessibilityForbidden,
+		},
+		{
+			name: "Regex ordering: nested scope with specificity at leaf level, allow case",
+			scope: AccessScope{
+				"api": AccessScope{
+					"r#^/users/.*$":         true,
+					"r#^/users/admin/.*$":   false,
+				},
+			},
+			args: args{path: "api|/users/42"},
+			want: constants.ScopeAccessibilityAccessible,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -173,6 +345,114 @@ func TestAccessScope_GetAccessibility(t *testing.T) {
 				t.Errorf("AccessScope.GetAccessibility() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSortedRegexScopeKeys(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope map[string]any
+		want  []string
+	}{
+		{
+			name:  "Empty map",
+			scope: map[string]any{},
+			want:  nil,
+		},
+		{
+			name:  "No regex keys",
+			scope: map[string]any{"/a": true, "/b": true},
+			want:  nil,
+		},
+		{
+			name: "Mixed keys — only regex keys are returned",
+			scope: map[string]any{
+				"/literal":     true,
+				"r#^/a/.*$":    true,
+				"another-lit":  false,
+				"r#^/longer/.$": true,
+			},
+			want: []string{"r#^/longer/.$", "r#^/a/.*$"},
+		},
+		{
+			name: "Length-descending ordering",
+			scope: map[string]any{
+				"r#^/short$":                          true,
+				"r#^/much/much/longer/pattern/here$":  true,
+				"r#^/medium/length$":                  true,
+			},
+			want: []string{
+				"r#^/much/much/longer/pattern/here$",
+				"r#^/medium/length$",
+				"r#^/short$",
+			},
+		},
+		{
+			name: "Length ties are broken lexicographically (deterministic)",
+			scope: map[string]any{
+				"r#^/a$": true,
+				"r#^/c$": true,
+				"r#^/b$": true,
+			},
+			want: []string{"r#^/a$", "r#^/b$", "r#^/c$"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sortedRegexScopeKeys(tt.scope)
+			if len(got) != len(tt.want) {
+				t.Fatalf("sortedRegexScopeKeys() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("sortedRegexScopeKeys()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetCompiledScopeRegex_CachesAndHandlesInvalid(t *testing.T) {
+	// Use unique patterns so other tests don't pollute this one.
+	validPattern := "^/cache-test/valid/[0-9]+$"
+	invalidPattern := "^/cache-test/invalid/(unterminated"
+
+	// Clean up after ourselves so repeat runs are hermetic.
+	defer regexCache.Delete(validPattern)
+	defer regexCache.Delete(invalidPattern)
+
+	// First call compiles and caches.
+	re1 := getCompiledScopeRegex(validPattern)
+	if re1 == nil {
+		t.Fatalf("getCompiledScopeRegex(%q) = nil, want compiled regex", validPattern)
+	}
+	if !re1.MatchString("/cache-test/valid/42") {
+		t.Errorf("compiled regex does not match expected input")
+	}
+
+	// Second call returns the SAME pointer (cache hit).
+	re2 := getCompiledScopeRegex(validPattern)
+	if re1 != re2 {
+		t.Errorf("getCompiledScopeRegex(%q) returned different pointers on subsequent calls; cache is not working", validPattern)
+	}
+
+	// Invalid pattern returns nil and caches the failure.
+	if got := getCompiledScopeRegex(invalidPattern); got != nil {
+		t.Errorf("getCompiledScopeRegex(%q) = %v, want nil", invalidPattern, got)
+	}
+	if got := getCompiledScopeRegex(invalidPattern); got != nil {
+		t.Errorf("getCompiledScopeRegex(%q) second call = %v, want nil (cached)", invalidPattern, got)
+	}
+	// The invalid entry should be present in the cache as a nil value.
+	if cached, ok := regexCache.Load(invalidPattern); !ok {
+		t.Errorf("invalid pattern was not cached")
+	} else if cached != nil {
+		// We explicitly store a typed nil, which survives as an interface
+		// holding (*regexp.Regexp)(nil); it is not == nil in a generic sense,
+		// but the value read out of it must itself be a nil pointer.
+		if rp, ok := cached.(*regexp.Regexp); !ok || rp != nil {
+			t.Errorf("invalid pattern cache entry = %#v, want typed nil *regexp.Regexp", cached)
+		}
 	}
 }
 
@@ -313,6 +593,37 @@ func TestFUPScope_GetLimit_HasLimit(t *testing.T) {
 			args:  args{path: "/test.prio.hourly"},
 			want:  nil,
 			has:   false,
+		},
+		// FUPScope specificity ordering: more specific regex wins over broader one.
+		{
+			name: "FUP regex ordering: specific regex wins over broad",
+			scope: FUPScope{
+				"r#^/api/v[0-9]+$":          map[string]any{"hourly": 321},
+				"r#^/api/v[0-9]+/premium$":  map[string]any{"hourly": 123},
+			},
+			args: args{path: "/api/v1/premium.hourly"},
+			want: &testValue,
+			has:  true,
+		},
+		{
+			name: "FUP regex ordering: broad regex used when specific does not match",
+			scope: FUPScope{
+				"r#^/api/v[0-9]+$":         map[string]any{"hourly": 123},
+				"r#^/api/v[0-9]+/premium$": map[string]any{"hourly": 321},
+			},
+			args: args{path: "/api/v1.hourly"},
+			want: &testValue,
+			has:  true,
+		},
+		{
+			name: "FUP regex ordering: exact match wins over more specific regex",
+			scope: FUPScope{
+				"/api/v1/premium":          map[string]any{"hourly": 123},
+				"r#^/api/v[0-9]+/premium$": map[string]any{"hourly": 999},
+			},
+			args: args{path: "/api/v1/premium.hourly"},
+			want: &testValue,
+			has:  true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Regex-enabled keys in `AccessScope` / `FUPScope` are now tried in **most-specific-first** order (pattern length descending, lexicographic tie-break), so a narrow deny rule reliably shadows a broader allow rule regardless of map iteration order.
- Compiled regexes are memoized in a process-wide `sync.Map`, so each pattern is compiled at most once per process. Invalid patterns are cached as typed-nil to avoid repeat compile attempts.
- Exact (non-regex) key lookups still win over any regex match.

## Why

Scope lookups previously iterated the underlying `map[string]any` in random order. With overlapping regexes this was non-deterministic — you couldn't, for example, layer

```json
{
  "/token/generate": true,
  "r#^/similarity/v[0-9]+/.*$": true,
  "r#^/similarity/v[0-9]+/(chat|sessions).*$": false
}
```

and trust that `/similarity/v1/chat` would be denied. Now it is: the longer (more specific) regex is tried first, and its `false` value shadows the broader allow.

## What changed

- `auth/contract/entity.go`
  - New helpers: `regexCache` + `getCompiledScopeRegex`, `sortedRegexScopeKeys`, `lookupScopeEntry`.
  - `AccessScope.GetAccessibility`, `FUPScope.GetLimit`, and `FUPScope.HasLimit` rewritten around the new helper. Leaf-type handling (bool/string/int/float32/float64) and nested-scope descent are preserved.
  - Segment walk now uses `for index, segment := range pathSegments`, which also fixes a latent bug in the old code where the inner regex loop's `continue` targeted the wrong loop after descending into a regex-matched nested scope.
- `auth/contract/entity_test.go`
  - 17 new `AccessScope` cases (the `/similarity/...` example, three-regex chains with middle-wins/most-specific-wins/least-specific-wins, exact-match-beats-regex, on-behalf vs deny precedence, invalid regex is skipped, deterministic length ties, nested-scope ordering).
  - 3 new `FUPScope` cases (specific-beats-broad, broad-fallback-when-specific-misses, exact-match precedence).
  - New `TestSortedRegexScopeKeys` — sorter unit tests (length desc + lex tie-break, ignores non-regex keys).
  - New `TestGetCompiledScopeRegex_CachesAndHandlesInvalid` — verifies pointer identity across repeat calls, nil return on invalid patterns, and that failures are cached.

## Notes for reviewers

- **Specificity metric**: pattern length (descending). Simple, deterministic, matches intuition for realistic path patterns. A pathological case like a short-but-heavily-constrained `a{1,100}` won't rank intuitively, but that hasn't come up in practice and we can revisit with a literal-character-count heuristic later.
- **No backtracking**: if a regex matches but its value is a nested scope, the walk commits to that scope — it doesn't back out to try a less-specific regex if later segments fail. Preserves the original behavior.
- **Cache lifetime**: process-wide and unbounded. Pattern strings come from configured scopes, not user input, so cardinality is bounded by config size.
- All existing tests still pass; `go vet ./...` is clean.

## Test plan

- [x] `go test ./auth/contract/...` — all passing (including 20+ new cases)
- [x] `go test ./...` — full suite green
- [x] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Access scope and rate limit lookups now utilize pattern caching for faster responses

* **Improvements**
  * Deterministic pattern matching ensures consistent behavior across requests
  * Enhanced error resilience in scope resolution

* **Tests**
  * Comprehensive new test coverage for pattern matching specificity and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->